### PR TITLE
fix createLogger args for createRollingFileLogger

### DIFF
--- a/lib/SimpleLogger.js
+++ b/lib/SimpleLogger.js
@@ -297,7 +297,7 @@ SimpleLogger.createRollingFileLogger = function(options) {
         process.nextTick( manager.startRefreshThread );
     }
 
-    return manager.createLogger( opts );
+    return manager.createLogger( opts.category, opts.level );
 };
 
 /**


### PR DESCRIPTION
Pulling opts.category and opts.level as separate args to createRollingFileLogger, instead of the single opts obj.