### PR TITLE
createLogger to accept obj, cascade setLevel to appenders

### DIFF
--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -67,6 +67,9 @@ var Logger = function(options) {
     this.setLevel = function(lvl) {
         currentLevel = levels.indexOf(lvl);
         level = lvl;
+        appenders.forEach( function(a){
+          a.setLevel(lvl)
+        })
     };
 
     /**

--- a/lib/SimpleLogger.js
+++ b/lib/SimpleLogger.js
@@ -34,24 +34,20 @@ var SimpleLogger = function(options) {
      * @param level
      */
     this.createLogger = function(category, level) {
-        var logger,
-            opts = {};
-
-        if (!level) level = dfltLevel;
-
-        opts.level = level;
+      var logger;
+  
+      var opts = 
+        Object.prototype.toString.call(category) === '[object String]'
+         ? options
+         : dash.merge({}, options, category)
+        
+        opts.category  = category ? category : opts.category;
+        opts.level     = level ? level : opts.level || dfltLevel;
         opts.appenders = appenders;
-
-        if (domain) {
-            opts.domain = domain;
-        }
-
-        if (category) opts.category = category;
-
+        
         logger = new Logger( opts );
-
         loggers.push( logger );
-
+        
         return logger;
     };
 

--- a/test/mocks/MockAppender.js
+++ b/test/mocks/MockAppender.js
@@ -6,10 +6,20 @@
  */
 var MockAppender = function() {
     'use strict';
-
+    var Logger = require('../lib/Logger' );
+    var level  = Logger.DEFAULT_LEVEL,
+        levels = Logger.STANDARD_LEVELS,
+        currentLevel = levels.indexOf( level );
     var appender = this;
 
     this.entries = [];
+
+    this.setLevel = function(level) {
+        var idx = levels.indexOf( level );
+        if (idx >= 0) {
+            currentLevel = idx;
+        }
+    };
 
     this.write = function(entry) {
         appender.entries.push( entry );

--- a/test/mocks/MockAppender.js
+++ b/test/mocks/MockAppender.js
@@ -6,7 +6,7 @@
  */
 var MockAppender = function() {
     'use strict';
-    var Logger = require('../lib/Logger' );
+    var Logger = require('../../lib/Logger' );
     var level  = Logger.DEFAULT_LEVEL,
         levels = Logger.STANDARD_LEVELS,
         currentLevel = levels.indexOf( level );


### PR DESCRIPTION
createLogger tests for an obj in argument[0], and now can accept
'level' and 'category' strings or a passed options obj.

calling setLevel in Logger will now call setLevel in each appender
to propogate the currentLevel value and allow writes to log after
setLevel() calls in scripts.