### PR TITLE
remove tests from npm package distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 node_modules
 file-test.log
 logs/
+test/

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 
 /** darryl.west@raincitysoftware.com **/
 
+const fs = require( 'fs' );
+
 module.exports = require('./lib/SimpleLogger');
 module.exports.AbstractAppender = require('./lib/AbstractAppender');
 module.exports.Logger = require('./lib/Logger');
@@ -11,8 +13,10 @@ module.exports.appenders = {
     RollingFileAppender:require('./lib/RollingFileAppender')
 };
 
-module.exports.mocks = {
-    MockAppender:require('./test/mocks/MockAppender'),
-    MockLogger:require('./test/mocks/MockLogger')
-};
+if (fs.existsSync('./test/')) {
+    module.exports.mocks = {
+        MockAppender: require('./test/mocks/MockAppender'),
+        MockLogger: require('./test/mocks/MockLogger')
+    };
+}
 


### PR DESCRIPTION
Add test directory to .npmignore, because we do not need test when you install this package

Motivation
If you want to use package for logging in micro-service architecture, probably you want to reduce the size of node_modules directory by different ways (alpine node image, lightweight packages instead of heavy, use tools like [modclean](https://github.com/ModClean/modclean)). So this PR helps with this a little bit