### PR TITLE
Added support for custom flags for `createWriteStream`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -157,6 +157,7 @@ declare namespace SimpleLogger
 		autoOpen?: boolean;
 		logFilePath: string;
 		writer?: any;
+		flags?: string;
 	}
 	export interface IRollingFileAppenderOptions extends IAbstractAppenderOptions
 	{

--- a/lib/FileAppender.js
+++ b/lib/FileAppender.js
@@ -18,6 +18,7 @@ const FileAppender = function(options) {
     const typeName = options.typeName || 'FileAppender';
     const autoOpen = dash.isBoolean( options.autoOpen ) ? options.autoOpen : true;
     const levels = options.levels || Logger.STANDARD_LEVELS;
+    const flags = options.flags || 'a'
 
     let level = options.level || Logger.DEFAULT_LEVEL;
     let currentLevel = levels.indexOf( level );
@@ -62,7 +63,7 @@ const FileAppender = function(options) {
         if (!writer) {
             const file = path.normalize( logFilePath );
             const opts = {
-                flags:'a',
+                flags,
                 encoding:'utf8'
             };
 


### PR DESCRIPTION
I wanted the logger to overwrite the log file every time it instantiated but the implementation wouldn't allow for custom flags passed to the `FileLogger` `createWriteStream` invocation, so I've added the possibility to pass in custom flags, and fallback to the default `'a'` flag.